### PR TITLE
Legger til inbound access for dp-arbeidssokerregister-adapter

### DIFF
--- a/apps/oppslag-api/nais/nais-dev.yaml
+++ b/apps/oppslag-api/nais/nais-dev.yaml
@@ -97,7 +97,7 @@ spec:
           namespace: teamdagpenger
         - application: dp-mine-dagpenger-frontend
           namespace: teamdagpenger
-        - application: dp-rapportering-personregister
+        - application: dp-arbeidssokerregister-adapter
           namespace: teamdagpenger
         - application: veilarbportefolje
           namespace: pto


### PR DESCRIPTION
Og fjerner dp-rapportering-personregister, da adapteret overtar.